### PR TITLE
Fix delete result type of global IP address sets

### DIFF
--- a/fic/eri/v1/routers/components/nat_global_ip_address_sets/results.go
+++ b/fic/eri/v1/routers/components/nat_global_ip_address_sets/results.go
@@ -36,7 +36,7 @@ type GetResult struct {
 
 // DeleteResult represents the result of a delete operation.
 type DeleteResult struct {
-	commonResult
+	fic.ErrResult
 }
 
 // GlobalIPAddressSet represents global ip address set resource.


### PR DESCRIPTION
Make DeleteResult include fic.ErrResult as well as other packages' ones