### PR TITLE
Fix OK status code of Delete global IP address sets

### DIFF
--- a/fic/eri/v1/routers/components/nat_global_ip_address_sets/requests.go
+++ b/fic/eri/v1/routers/components/nat_global_ip_address_sets/requests.go
@@ -81,6 +81,6 @@ func Create(c *fic.ServiceClient, routerID, natID string, opts CreateOptsBuilder
 
 // Delete accepts a unique ID and deletes the global ip address set associated with it.
 func Delete(c *fic.ServiceClient, routerID, natID, globalIPAddressSetID string) (r DeleteResult) {
-	_, r.Err = c.Delete(deleteURL(c, routerID, natID, globalIPAddressSetID), nil)
+	_, r.Err = c.Delete(deleteURL(c, routerID, natID, globalIPAddressSetID), &fic.RequestOpts{OkCodes: []int{200}})
 	return
 }

--- a/fic/eri/v1/routers/components/nat_global_ip_address_sets/testing/requests_test.go
+++ b/fic/eri/v1/routers/components/nat_global_ip_address_sets/testing/requests_test.go
@@ -95,7 +95,7 @@ func TestGetGlobalIPAddressSet(t *testing.T) {
 	th.CheckDeepEquals(t, &gip1, ip)
 }
 
-func TestCreateGLobalIPAddressSet(t *testing.T) {
+func TestCreateGlobalIPAddressSet(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
@@ -124,7 +124,7 @@ func TestCreateGLobalIPAddressSet(t *testing.T) {
 	th.AssertDeepEquals(t, &gip1Created, p)
 }
 
-func TestDeletePort(t *testing.T) {
+func TestDeleteGlobalIPAddressSet(t *testing.T) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
@@ -132,7 +132,7 @@ func TestDeletePort(t *testing.T) {
 	th.Mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "DELETE")
 		th.TestHeader(t, r, "X-Auth-Token", TokenID)
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusOK)
 	})
 
 	res := nat_global_ip_address_sets.Delete(fakeclient.ServiceClient(), idRouter, idNAT, idGIP1)


### PR DESCRIPTION
Fix OK code to 200 of Delete method
https://fic.ntt.com/documents/api-references/component-nat/rsts/NAT%20Global%20IP.html#id18