### PR TITLE
Add unsupported parameters of gcp connection

### DIFF
--- a/fic/eri/v1/router_paired_to_gcp_connections/doc.go
+++ b/fic/eri/v1/router_paired_to_gcp_connections/doc.go
@@ -46,12 +46,12 @@ Example to Create a Connection
 				Out: "privateRoute",
 			},
 			Primary: con.SourceHAInfo{
-				MED: &con.MED{
+				MED: con.MED{
 					Out: 10,
 				},
 			},
 			Secondary: con.SourceHAInfo{
-				MED: &con.MED{
+				MED: con.MED{
 					Out: 20,
 				},
 			},
@@ -93,12 +93,12 @@ Example to Update a Connection
 				Out: "fullRoute",
 			},
 			Primary: con.SourceHAInfo{
-				MED: &con.MED{
+				MED: con.MED{
 					Out: 30,
 				},
 			},
 			Secondary: con.SourceHAInfo{
-				MED: &con.MED{
+				MED: con.MED{
 					Out: 40,
 				},
 			},

--- a/fic/eri/v1/router_paired_to_gcp_connections/doc.go
+++ b/fic/eri/v1/router_paired_to_gcp_connections/doc.go
@@ -45,7 +45,7 @@ Example to Create a Connection
 				In:  "noRoute",
 				Out: "privateRoute",
 			},
-            Primary: con.SourceHAInfo{
+			Primary: con.SourceHAInfo{
 				MED: &con.MED{
 					Out: 10,
 				},
@@ -92,7 +92,7 @@ Example to Update a Connection
 				In:  "fullRoute",
 				Out: "fullRoute",
 			},
-            Primary: con.SourceHAInfo{
+			Primary: con.SourceHAInfo{
 				MED: &con.MED{
 					Out: 30,
 				},

--- a/fic/eri/v1/router_paired_to_gcp_connections/doc.go
+++ b/fic/eri/v1/router_paired_to_gcp_connections/doc.go
@@ -45,6 +45,16 @@ Example to Create a Connection
 				In:  "noRoute",
 				Out: "privateRoute",
 			},
+            Primary: con.SourceHAInfo{
+				MED: &con.MED{
+					Out: 10,
+				},
+			},
+			Secondary: con.SourceHAInfo{
+				MED: &con.MED{
+					Out: 20,
+				},
+			},
 		},
 		Destination: con.Destination{
 			Primary: con.DestinationHAInfo{
@@ -82,7 +92,18 @@ Example to Update a Connection
 				In:  "fullRoute",
 				Out: "fullRoute",
 			},
+            Primary: con.SourceHAInfo{
+				MED: &con.MED{
+					Out: 30,
+				},
+			},
+			Secondary: con.SourceHAInfo{
+				MED: &con.MED{
+					Out: 40,
+				},
+			},
 		},
+		Bandwidth: "200M",
 	}
 	connectionID := "484cda0e-106f-4f4b-bb3f-d413710bbe78"
 	c, err := con.Update(fakeclient.ServiceClient(), connectionID, updateOpts).Extract()

--- a/fic/eri/v1/router_paired_to_gcp_connections/requests.go
+++ b/fic/eri/v1/router_paired_to_gcp_connections/requests.go
@@ -68,7 +68,7 @@ type RouteFilter struct {
 
 // MED represents MED value
 type MED struct {
-	Out int `json:"out"`
+	Out int `json:"out" required:"true"`
 }
 
 // SourceHAInfo represents Primary/Secondary parameters
@@ -87,7 +87,7 @@ type Destination struct {
 	// AWSAccountID string            `json:"awsAccountId" required:"true"`
 	QosType   string            `json:"qosType" required:"true"`
 	Primary   DestinationHAInfo `json:"primary" required:"true"`
-	Secondary DestinationHAInfo `json:"secondary,omitempty"`
+	Secondary DestinationHAInfo `json:"secondary" required:"true"`
 }
 
 // Source represents source parameter for connection.
@@ -102,8 +102,8 @@ type Source struct {
 // CreateOpts represents options used to create a connection.
 type CreateOpts struct {
 	Name        string      `json:"name" required:"true"`
-	Source      Source      `json:"source"`
-	Destination Destination `json:"destination"`
+	Source      Source      `json:"source" required:"true"`
+	Destination Destination `json:"destination" required:"true"`
 	Bandwidth   string      `json:"bandwidth" required:"true"`
 	// PrimaryConnectedNetworkAddress   string      `json:"primaryConnectedNwAddress"`
 	// SecondaryConnectedNetworkAddress string      `json:"secondaryConnectedNwAddress"`
@@ -151,7 +151,7 @@ type SourceForUpdate struct {
 
 // UpdateOpts represents options used to update a connection.
 type UpdateOpts struct {
-	Source    SourceForUpdate `json:"source"`
+	Source    SourceForUpdate `json:"source" required:"true"`
 	Bandwidth string          `json:"bandwidth" required:"true"`
 }
 

--- a/fic/eri/v1/router_paired_to_gcp_connections/requests.go
+++ b/fic/eri/v1/router_paired_to_gcp_connections/requests.go
@@ -66,6 +66,17 @@ type RouteFilter struct {
 	Out string `json:"out" required:"true"`
 }
 
+// MED represents MED value
+type MED struct {
+	Out int `json:"out"`
+}
+
+// SourceHAInfo represents Primary/Secondary parameters
+// for Source of Connection.
+type SourceHAInfo struct {
+	MED *MED `json:"med" required:"true"`
+}
+
 type DestinationHAInfo struct {
 	Interconnect string `json:"interconnect" required:"true"`
 	PairingKey   string `json:"pairingKey" required:"true"`
@@ -81,9 +92,11 @@ type Destination struct {
 
 // Source represents source parameter for connection.
 type Source struct {
-	RouterID    string      `json:"routerId" required:"true"`
-	GroupName   string      `json:"groupName" required:"true"`
-	RouteFilter RouteFilter `json:"routeFilter" required:"true"`
+	RouterID    string       `json:"routerId" required:"true"`
+	GroupName   string       `json:"groupName" required:"true"`
+	RouteFilter RouteFilter  `json:"routeFilter" required:"true"`
+	Primary     SourceHAInfo `json:"primary" required:"true"`
+	Secondary   SourceHAInfo `json:"secondary" required:"true"`
 }
 
 // CreateOpts represents options used to create a connection.
@@ -91,7 +104,7 @@ type CreateOpts struct {
 	Name        string      `json:"name" required:"true"`
 	Source      Source      `json:"source"`
 	Destination Destination `json:"destination"`
-	Bandwidth   string      `json:"bandwidth"`
+	Bandwidth   string      `json:"bandwidth" required:"true"`
 	// PrimaryConnectedNetworkAddress   string      `json:"primaryConnectedNwAddress"`
 	// SecondaryConnectedNetworkAddress string      `json:"secondaryConnectedNwAddress"`
 }
@@ -131,12 +144,15 @@ type UpdateOptsBuilder interface {
 
 // SourceForUpdate represents Source parameter in case of Updating.
 type SourceForUpdate struct {
-	RouteFilter RouteFilter `json:"routeFilter" required:"true"`
+	RouteFilter RouteFilter  `json:"routeFilter" required:"true"`
+	Primary     SourceHAInfo `json:"primary" required:"true"`
+	Secondary   SourceHAInfo `json:"secondary" required:"true"`
 }
 
 // UpdateOpts represents options used to update a connection.
 type UpdateOpts struct {
-	Source SourceForUpdate `json:"source"`
+	Source    SourceForUpdate `json:"source"`
+	Bandwidth string          `json:"bandwidth" required:"true"`
 }
 
 // ToUpdateMap builds a request body from UpdateOpts.

--- a/fic/eri/v1/router_paired_to_gcp_connections/requests.go
+++ b/fic/eri/v1/router_paired_to_gcp_connections/requests.go
@@ -74,7 +74,7 @@ type MED struct {
 // SourceHAInfo represents Primary/Secondary parameters
 // for Source of Connection.
 type SourceHAInfo struct {
-	MED *MED `json:"med" required:"true"`
+	MED MED `json:"med" required:"true"`
 }
 
 type DestinationHAInfo struct {
@@ -84,7 +84,6 @@ type DestinationHAInfo struct {
 
 // Destination represents destination parameter for connection.
 type Destination struct {
-	// AWSAccountID string            `json:"awsAccountId" required:"true"`
 	QosType   string            `json:"qosType" required:"true"`
 	Primary   DestinationHAInfo `json:"primary" required:"true"`
 	Secondary DestinationHAInfo `json:"secondary" required:"true"`
@@ -105,8 +104,6 @@ type CreateOpts struct {
 	Source      Source      `json:"source" required:"true"`
 	Destination Destination `json:"destination" required:"true"`
 	Bandwidth   string      `json:"bandwidth" required:"true"`
-	// PrimaryConnectedNetworkAddress   string      `json:"primaryConnectedNwAddress"`
-	// SecondaryConnectedNetworkAddress string      `json:"secondaryConnectedNwAddress"`
 }
 
 // ToConnectionCreateMap builds a request body from CreateOpts.

--- a/fic/eri/v1/router_paired_to_gcp_connections/results.go
+++ b/fic/eri/v1/router_paired_to_gcp_connections/results.go
@@ -49,6 +49,7 @@ type UpdateResult struct {
 type Connection struct {
 	ID                               string      `json:"id"`
 	TenantID                         string      `json:"tenantId"`
+	Area                             string      `json:"area"`
 	OperationStatus                  string      `json:"operationStatus"`
 	Redundant                        bool        `json:"redundant"`
 	Name                             string      `json:"name"`

--- a/fic/eri/v1/router_paired_to_gcp_connections/testing/fixtures.go
+++ b/fic/eri/v1/router_paired_to_gcp_connections/testing/fixtures.go
@@ -72,12 +72,12 @@ var connection1 = con.Connection{
 			Out: "privateRoute",
 		},
 		Primary: con.SourceHAInfo{
-			MED: &con.MED{
+			MED: con.MED{
 				Out: 10,
 			},
 		},
 		Secondary: con.SourceHAInfo{
-			MED: &con.MED{
+			MED: con.MED{
 				Out: 20,
 			},
 		},
@@ -247,12 +247,12 @@ var connectionCreated = con.Connection{
 			Out: "privateRoute",
 		},
 		Primary: con.SourceHAInfo{
-			MED: &con.MED{
+			MED: con.MED{
 				Out: 10,
 			},
 		},
 		Secondary: con.SourceHAInfo{
-			MED: &con.MED{
+			MED: con.MED{
 				Out: 20,
 			},
 		},
@@ -358,12 +358,12 @@ var connectionUpdated = con.Connection{
 			Out: "fullRoute",
 		},
 		Primary: con.SourceHAInfo{
-			MED: &con.MED{
+			MED: con.MED{
 				Out: 30,
 			},
 		},
 		Secondary: con.SourceHAInfo{
-			MED: &con.MED{
+			MED: con.MED{
 				Out: 40,
 			},
 		},

--- a/fic/eri/v1/router_paired_to_gcp_connections/testing/fixtures.go
+++ b/fic/eri/v1/router_paired_to_gcp_connections/testing/fixtures.go
@@ -13,10 +13,11 @@ var listResponse = fmt.Sprintf(`
     "connections": [
         {
             "id": "%s",
-            "tenantId": "87e89b8f075a4ee1aa209f6ca6ce242c",
-            "operationStatus": "Completed",
-            "redundant": true,
             "name": "YourConnectionName",
+            "redundant": true,
+            "tenantId": "87e89b8f075a4ee1aa209f6ca6ce242c",
+            "area": "JPEAST",
+            "operationStatus": "Completed",
             "bandwidth": "100M",
             "source": {
                 "routerId": "F020123456789",
@@ -24,16 +25,26 @@ var listResponse = fmt.Sprintf(`
                 "routeFilter": {
                     "in": "noRoute",
                     "out": "privateRoute"
+                },
+                "primary": {
+                    "med": {
+                        "out": 10
+                    }
+                },
+                "secondary": {
+                    "med": {
+                        "out": 20
+                    }
                 }
             },
             "destination": {
                 "primary": {
-                    "interconnect": "@Tokyo-CC2-1",
+                    "interconnect": "@Tokyo-CC2-2",
                     "pairingKey": "d27476e6-e8a8-4214-a88f-9d3131db465d/asia-northeast1/2"
                 },
                 "qosType": "guarantee",
                 "secondary": {
-                    "interconnect": "@Tokyo-CC2-1",
+                    "interconnect": "@Tokyo-CC2-2",
                     "pairingKey": "17c64c4e-f845-4450-82e9-843095e18526/asia-northeast1/2"
                 }
             },
@@ -48,6 +59,7 @@ var listResponse = fmt.Sprintf(`
 var connection1 = con.Connection{
 	ID:              idConnection1,
 	TenantID:        "87e89b8f075a4ee1aa209f6ca6ce242c",
+	Area:            "JPEAST",
 	OperationStatus: "Completed",
 	Redundant:       true,
 	Name:            "YourConnectionName",
@@ -59,15 +71,25 @@ var connection1 = con.Connection{
 			In:  "noRoute",
 			Out: "privateRoute",
 		},
+		Primary: con.SourceHAInfo{
+			MED: &con.MED{
+				Out: 10,
+			},
+		},
+		Secondary: con.SourceHAInfo{
+			MED: &con.MED{
+				Out: 20,
+			},
+		},
 	},
 	Destination: con.Destination{
 		Primary: con.DestinationHAInfo{
-			Interconnect: "@Tokyo-CC2-1",
+			Interconnect: "@Tokyo-CC2-2",
 			PairingKey:   "d27476e6-e8a8-4214-a88f-9d3131db465d/asia-northeast1/2",
 		},
 		QosType: "guarantee",
 		Secondary: con.DestinationHAInfo{
-			Interconnect: "@Tokyo-CC2-1",
+			Interconnect: "@Tokyo-CC2-2",
 			PairingKey:   "17c64c4e-f845-4450-82e9-843095e18526/asia-northeast1/2",
 		},
 	},
@@ -83,10 +105,11 @@ var getResponse = fmt.Sprintf(`
 {
     "connection": {
         "id": "%s",
-        "tenantId": "87e89b8f075a4ee1aa209f6ca6ce242c",
-        "operationStatus": "Completed",
-        "redundant": true,
         "name": "YourConnectionName",
+        "redundant": true,
+        "tenantId": "87e89b8f075a4ee1aa209f6ca6ce242c",
+        "area": "JPEAST",
+        "operationStatus": "Completed",
         "bandwidth": "100M",
         "source": {
             "routerId": "F020123456789",
@@ -94,16 +117,26 @@ var getResponse = fmt.Sprintf(`
             "routeFilter": {
                 "in": "noRoute",
                 "out": "privateRoute"
+            },
+            "primary": {
+                "med": {
+                    "out": 10
+                }
+            },
+            "secondary": {
+                "med": {
+                    "out": 20
+                }
             }
         },
         "destination": {
             "primary": {
-                "interconnect": "@Tokyo-CC2-1",
+                "interconnect": "@Tokyo-CC2-2",
                 "pairingKey": "d27476e6-e8a8-4214-a88f-9d3131db465d/asia-northeast1/2"
             },
             "qosType": "guarantee",
             "secondary": {
-                "interconnect": "@Tokyo-CC2-1",
+                "interconnect": "@Tokyo-CC2-2",
                 "pairingKey": "17c64c4e-f845-4450-82e9-843095e18526/asia-northeast1/2"
             }
         },
@@ -125,15 +158,25 @@ const createRequest = `
             "routeFilter": {
                 "in": "noRoute",
                 "out": "privateRoute"
+            },
+            "primary": {
+                "med": {
+                    "out": 10
+                }
+            },
+            "secondary": {
+                "med": {
+                    "out": 20
+                }
             }
         },
         "destination": {
             "primary": {
-                "interconnect": "@Tokyo-CC2-1",
+                "interconnect": "@Tokyo-CC2-2",
                 "pairingKey": "d27476e6-e8a8-4214-a88f-9d3131db465d/asia-northeast1/2"
             },
             "secondary": {
-                "interconnect": "@Tokyo-CC2-1",
+                "interconnect": "@Tokyo-CC2-2",
                 "pairingKey": "17c64c4e-f845-4450-82e9-843095e18526/asia-northeast1/2"
             },
             "qosType": "guarantee"
@@ -146,10 +189,11 @@ var createResponse = fmt.Sprintf(`
 {
     "connection": {
         "id": "%s",
-        "tenantId": "87e89b8f075a4ee1aa209f6ca6ce242c",
-        "operationStatus": "Processing",
-        "redundant": true,
         "name": "YourConnectionName",
+        "redundant": true,
+        "tenantId": "87e89b8f075a4ee1aa209f6ca6ce242c",
+        "area": "JPEAST",
+        "operationStatus": "Processing",
         "bandwidth": "100M",
         "source": {
             "routerId": "F020123456789",
@@ -157,16 +201,26 @@ var createResponse = fmt.Sprintf(`
             "routeFilter": {
                 "in": "noRoute",
                 "out": "privateRoute"
+            },
+            "primary": {
+                "med": {
+                    "out": 10
+                }
+            },
+            "secondary": {
+                "med": {
+                    "out": 20
+                }
             }
         },
         "destination": {
             "primary": {
-                "interconnect": "@Tokyo-CC2-1",
+                "interconnect": "@Tokyo-CC2-2",
                 "pairingKey": "d27476e6-e8a8-4214-a88f-9d3131db465d/asia-northeast1/2"
             },
             "qosType": "guarantee",
             "secondary": {
-                "interconnect": "@Tokyo-CC2-1",
+                "interconnect": "@Tokyo-CC2-2",
                 "pairingKey": "17c64c4e-f845-4450-82e9-843095e18526/asia-northeast1/2"
             }
         },
@@ -180,6 +234,7 @@ var createResponse = fmt.Sprintf(`
 var connectionCreated = con.Connection{
 	ID:              idConnection1,
 	TenantID:        "87e89b8f075a4ee1aa209f6ca6ce242c",
+	Area:            "JPEAST",
 	OperationStatus: "Processing",
 	Redundant:       true,
 	Name:            "YourConnectionName",
@@ -191,15 +246,25 @@ var connectionCreated = con.Connection{
 			In:  "noRoute",
 			Out: "privateRoute",
 		},
+		Primary: con.SourceHAInfo{
+			MED: &con.MED{
+				Out: 10,
+			},
+		},
+		Secondary: con.SourceHAInfo{
+			MED: &con.MED{
+				Out: 20,
+			},
+		},
 	},
 	Destination: con.Destination{
 		Primary: con.DestinationHAInfo{
-			Interconnect: "@Tokyo-CC2-1",
+			Interconnect: "@Tokyo-CC2-2",
 			PairingKey:   "d27476e6-e8a8-4214-a88f-9d3131db465d/asia-northeast1/2",
 		},
 		QosType: "guarantee",
 		Secondary: con.DestinationHAInfo{
-			Interconnect: "@Tokyo-CC2-1",
+			Interconnect: "@Tokyo-CC2-2",
 			PairingKey:   "17c64c4e-f845-4450-82e9-843095e18526/asia-northeast1/2",
 		},
 	},
@@ -213,8 +278,19 @@ const updateRequest = `
             "routeFilter": {
                 "in": "fullRoute",
                 "out": "fullRoute"
+            },
+            "primary": {
+                "med": {
+                    "out": 30
+                }
+            },
+            "secondary": {
+                "med": {
+                    "out": 40
+                }
             }
-        }
+        },
+        "bandwidth": "200M"
     }
 }`
 
@@ -222,27 +298,38 @@ var updateResponse = fmt.Sprintf(`
 {
     "connection": {
         "id": "%s",
-        "tenantId": "87e89b8f075a4ee1aa209f6ca6ce242c",
-        "operationStatus": "Processing",
-        "redundant": true,
         "name": "YourConnectionName",
-        "bandwidth": "100M",
+        "redundant": true,
+        "tenantId": "87e89b8f075a4ee1aa209f6ca6ce242c",
+        "area": "JPEAST",
+        "operationStatus": "Processing",
+        "bandwidth": "200M",
         "source": {
             "routerId": "F020123456789",
             "groupName": "group_1",
             "routeFilter": {
                 "in": "fullRoute",
                 "out": "fullRoute"
+            },
+            "primary": {
+                "med": {
+                    "out": 30
+                }
+            },
+            "secondary": {
+                "med": {
+                    "out": 40
+                }
             }
         },
         "destination": {
             "primary": {
-                "interconnect": "@Tokyo-CC2-1",
+                "interconnect": "@Tokyo-CC2-2",
                 "pairingKey": "d27476e6-e8a8-4214-a88f-9d3131db465d/asia-northeast1/2"
             },
             "qosType": "guarantee",
             "secondary": {
-                "interconnect": "@Tokyo-CC2-1",
+                "interconnect": "@Tokyo-CC2-2",
                 "pairingKey": "17c64c4e-f845-4450-82e9-843095e18526/asia-northeast1/2"
             }
         },
@@ -258,10 +345,11 @@ var updateResponse = fmt.Sprintf(`
 var connectionUpdated = con.Connection{
 	ID:              idConnection1,
 	TenantID:        "87e89b8f075a4ee1aa209f6ca6ce242c",
+	Area:            "JPEAST",
 	OperationStatus: "Processing",
 	Redundant:       true,
 	Name:            "YourConnectionName",
-	Bandwidth:       "100M",
+	Bandwidth:       "200M",
 	Source: con.Source{
 		RouterID:  "F020123456789",
 		GroupName: "group_1",
@@ -269,15 +357,25 @@ var connectionUpdated = con.Connection{
 			In:  "fullRoute",
 			Out: "fullRoute",
 		},
+		Primary: con.SourceHAInfo{
+			MED: &con.MED{
+				Out: 30,
+			},
+		},
+		Secondary: con.SourceHAInfo{
+			MED: &con.MED{
+				Out: 40,
+			},
+		},
 	},
 	Destination: con.Destination{
 		Primary: con.DestinationHAInfo{
-			Interconnect: "@Tokyo-CC2-1",
+			Interconnect: "@Tokyo-CC2-2",
 			PairingKey:   "d27476e6-e8a8-4214-a88f-9d3131db465d/asia-northeast1/2",
 		},
 		QosType: "guarantee",
 		Secondary: con.DestinationHAInfo{
-			Interconnect: "@Tokyo-CC2-1",
+			Interconnect: "@Tokyo-CC2-2",
 			PairingKey:   "17c64c4e-f845-4450-82e9-843095e18526/asia-northeast1/2",
 		},
 	},

--- a/fic/eri/v1/router_paired_to_gcp_connections/testing/requests_test.go
+++ b/fic/eri/v1/router_paired_to_gcp_connections/testing/requests_test.go
@@ -118,12 +118,12 @@ func TestCreateConnection(t *testing.T) {
 				Out: "privateRoute",
 			},
 			Primary: con.SourceHAInfo{
-				MED: &con.MED{
+				MED: con.MED{
 					Out: 10,
 				},
 			},
 			Secondary: con.SourceHAInfo{
-				MED: &con.MED{
+				MED: con.MED{
 					Out: 20,
 				},
 			},
@@ -188,12 +188,12 @@ func TestUpdateConnection(t *testing.T) {
 				Out: "fullRoute",
 			},
 			Primary: con.SourceHAInfo{
-				MED: &con.MED{
+				MED: con.MED{
 					Out: 30,
 				},
 			},
 			Secondary: con.SourceHAInfo{
-				MED: &con.MED{
+				MED: con.MED{
 					Out: 40,
 				},
 			},

--- a/fic/eri/v1/router_paired_to_gcp_connections/testing/requests_test.go
+++ b/fic/eri/v1/router_paired_to_gcp_connections/testing/requests_test.go
@@ -117,14 +117,24 @@ func TestCreateConnection(t *testing.T) {
 				In:  "noRoute",
 				Out: "privateRoute",
 			},
+			Primary: con.SourceHAInfo{
+				MED: &con.MED{
+					Out: 10,
+				},
+			},
+			Secondary: con.SourceHAInfo{
+				MED: &con.MED{
+					Out: 20,
+				},
+			},
 		},
 		Destination: con.Destination{
 			Primary: con.DestinationHAInfo{
-				Interconnect: "@Tokyo-CC2-1",
+				Interconnect: "@Tokyo-CC2-2",
 				PairingKey:   "d27476e6-e8a8-4214-a88f-9d3131db465d/asia-northeast1/2",
 			},
 			Secondary: con.DestinationHAInfo{
-				Interconnect: "@Tokyo-CC2-1",
+				Interconnect: "@Tokyo-CC2-2",
 				PairingKey:   "17c64c4e-f845-4450-82e9-843095e18526/asia-northeast1/2",
 			},
 			QosType: "guarantee",
@@ -177,7 +187,18 @@ func TestUpdateConnection(t *testing.T) {
 				In:  "fullRoute",
 				Out: "fullRoute",
 			},
+			Primary: con.SourceHAInfo{
+				MED: &con.MED{
+					Out: 30,
+				},
+			},
+			Secondary: con.SourceHAInfo{
+				MED: &con.MED{
+					Out: 40,
+				},
+			},
 		},
+		Bandwidth: "200M",
 	}
 	c, err := con.Update(fakeclient.ServiceClient(), idConnection1, updateOpts).Extract()
 	th.AssertNoErr(t, err)

--- a/fic/eri/v1/router_single_to_gcp_connections/doc.go
+++ b/fic/eri/v1/router_single_to_gcp_connections/doc.go
@@ -93,6 +93,7 @@ Example to Update a Connection
 				},
 			},
 		},
+		Bandwidth: "200M",
 	}
 	connectionID := "484cda0e-106f-4f4b-bb3f-d413710bbe78"
 	c, err := con.Update(fakeclient.ServiceClient(), connectionID, updateOpts).Extract()

--- a/fic/eri/v1/router_single_to_gcp_connections/requests.go
+++ b/fic/eri/v1/router_single_to_gcp_connections/requests.go
@@ -138,7 +138,8 @@ type SourceForUpdate struct {
 
 // UpdateOpts represents options used to update a connection.
 type UpdateOpts struct {
-	Source SourceForUpdate `json:"source"`
+	Source    SourceForUpdate `json:"source"`
+	Bandwidth string          `json:"bandwidth" required:"true"`
 }
 
 // ToUpdateMap builds a request body from UpdateOpts.

--- a/fic/eri/v1/router_single_to_gcp_connections/requests.go
+++ b/fic/eri/v1/router_single_to_gcp_connections/requests.go
@@ -92,9 +92,9 @@ type Source struct {
 // CreateOpts represents options used to create a connection.
 type CreateOpts struct {
 	Name        string      `json:"name" required:"true"`
-	Source      Source      `json:"source"`
-	Destination Destination `json:"destination"`
-	Bandwidth   string      `json:"bandwidth"`
+	Source      Source      `json:"source" required:"true"`
+	Destination Destination `json:"destination" required:"true"`
+	Bandwidth   string      `json:"bandwidth" required:"true"`
 }
 
 // ToConnectionCreateMap builds a request body from CreateOpts.
@@ -138,7 +138,7 @@ type SourceForUpdate struct {
 
 // UpdateOpts represents options used to update a connection.
 type UpdateOpts struct {
-	Source    SourceForUpdate `json:"source"`
+	Source    SourceForUpdate `json:"source" required:"true"`
 	Bandwidth string          `json:"bandwidth" required:"true"`
 }
 

--- a/fic/eri/v1/router_single_to_gcp_connections/results.go
+++ b/fic/eri/v1/router_single_to_gcp_connections/results.go
@@ -49,6 +49,7 @@ type UpdateResult struct {
 type Connection struct {
 	ID                             string      `json:"id"`
 	TenantID                       string      `json:"tenantId"`
+	Area                           string      `json:"area"`
 	OperationStatus                string      `json:"operationStatus"`
 	Redundant                      bool        `json:"redundant"`
 	Name                           string      `json:"name"`

--- a/fic/eri/v1/router_single_to_gcp_connections/testing/fixtures.go
+++ b/fic/eri/v1/router_single_to_gcp_connections/testing/fixtures.go
@@ -9,7 +9,6 @@ import (
 const idConnection1 = "F010123456789"
 
 var one = interface{}(1)
-var two = interface{}(2)
 var null = interface{}(nil)
 
 var listResponse = fmt.Sprintf(`
@@ -17,10 +16,11 @@ var listResponse = fmt.Sprintf(`
     "connections": [
         {
             "id": "%s",
-            "tenantId": "87e89b8f075a4ee1aa209f6ca6ce242c",
-            "operationStatus": "Completed",
-            "redundant": false,
             "name": "YourConnectionName",
+            "redundant": false,
+            "tenantId": "87e89b8f075a4ee1aa209f6ca6ce242c",
+            "area": "JPEAST",
+            "operationStatus": "Completed",
             "bandwidth": "300M",
             "source": {
                 "routerId": "F020123456789",
@@ -31,14 +31,14 @@ var listResponse = fmt.Sprintf(`
                 },
                 "primary": {
                     "asPathPrepend": {
-                        "in": 1,
+                        "in": null,
                         "out": null
                     }
                 }
             },
             "destination": {
                 "primary": {
-                    "interconnect": "Equinix-TY2-1",
+                    "interconnect": "Equinix-TY2-2",
                     "pairingKey": "4f043662-2ed6-45b0-8c3a-77d685716e28/asia-northeast1/2"
                 },
                 "qosType": "guarantee"
@@ -54,6 +54,7 @@ var listResponse = fmt.Sprintf(`
 var connection1 = con.Connection{
 	ID:              idConnection1,
 	TenantID:        "87e89b8f075a4ee1aa209f6ca6ce242c",
+	Area:            "JPEAST",
 	OperationStatus: "Completed",
 	Redundant:       false,
 	Name:            "YourConnectionName",
@@ -67,14 +68,14 @@ var connection1 = con.Connection{
 		},
 		Primary: con.Primary{
 			ASPathPrepend: con.ASPathPrepend{
-				In:  &one,
+				In:  &null,
 				Out: &null,
 			},
 		},
 	},
 	Destination: con.Destination{
 		Primary: con.DestinationHAInfo{
-			Interconnect: "Equinix-TY2-1",
+			Interconnect: "Equinix-TY2-2",
 			PairingKey:   "4f043662-2ed6-45b0-8c3a-77d685716e28/asia-northeast1/2",
 		},
 		QosType: "guarantee",
@@ -90,10 +91,11 @@ var getResponse = fmt.Sprintf(`
 {
     "connection": {
         "id": "%s",
-        "tenantId": "87e89b8f075a4ee1aa209f6ca6ce242c",
-        "operationStatus": "Completed",
-        "redundant": false,
         "name": "YourConnectionName",
+        "redundant": false,
+        "tenantId": "87e89b8f075a4ee1aa209f6ca6ce242c",
+        "area": "JPEAST",
+        "operationStatus": "Completed",
         "bandwidth": "300M",
         "source": {
             "routerId": "F020123456789",
@@ -104,14 +106,14 @@ var getResponse = fmt.Sprintf(`
             },
             "primary": {
                 "asPathPrepend": {
-                    "in": 1,
+                    "in": null,
                     "out": null
                 }
             }
         },
         "destination": {
             "primary": {
-                "interconnect": "Equinix-TY2-1",
+                "interconnect": "Equinix-TY2-2",
                 "pairingKey": "4f043662-2ed6-45b0-8c3a-77d685716e28/asia-northeast1/2"
             },
             "qosType": "guarantee"
@@ -136,14 +138,14 @@ const createRequest = `
             },
             "primary": {
                 "asPathPrepend": {
-                    "in": 1,
+                    "in": null,
                     "out": null
                 }
             }
         },
         "destination": {
             "primary": {
-                "interconnect": "Equinix-TY2-1",
+                "interconnect": "Equinix-TY2-2",
                 "pairingKey": "4f043662-2ed6-45b0-8c3a-77d685716e28/asia-northeast1/2"
             },
             "qosType": "guarantee"
@@ -157,10 +159,11 @@ var createResponse = fmt.Sprintf(`
 {
     "connection": {
         "id": "%s",
-        "tenantId": "87e89b8f075a4ee1aa209f6ca6ce242c",
-        "operationStatus": "Processing",
-        "redundant": false,
         "name": "YourConnectionName",
+        "redundant": false,
+        "tenantId": "87e89b8f075a4ee1aa209f6ca6ce242c",
+        "area": "JPEAST",
+        "operationStatus": "Processing",
         "bandwidth": "300M",
         "source": {
             "routerId": "F020123456789",
@@ -171,14 +174,14 @@ var createResponse = fmt.Sprintf(`
             },
             "primary": {
                 "asPathPrepend": {
-                    "in": 1,
+                    "in": null,
                     "out": null
                 }
             }
         },
         "destination": {
             "primary": {
-                "interconnect": "Equinix-TY2-1",
+                "interconnect": "Equinix-TY2-2",
                 "pairingKey": "4f043662-2ed6-45b0-8c3a-77d685716e28/asia-northeast1/2"
             },
             "qosType": "guarantee"
@@ -193,6 +196,7 @@ var createResponse = fmt.Sprintf(`
 var connectionCreated = con.Connection{
 	ID:              idConnection1,
 	TenantID:        "87e89b8f075a4ee1aa209f6ca6ce242c",
+	Area:            "JPEAST",
 	OperationStatus: "Processing",
 	Redundant:       false,
 	Name:            "YourConnectionName",
@@ -206,14 +210,14 @@ var connectionCreated = con.Connection{
 		},
 		Primary: con.Primary{
 			ASPathPrepend: con.ASPathPrepend{
-				In:  &one,
+				In:  &null,
 				Out: &null,
 			},
 		},
 	},
 	Destination: con.Destination{
 		Primary: con.DestinationHAInfo{
-			Interconnect: "Equinix-TY2-1",
+			Interconnect: "Equinix-TY2-2",
 			PairingKey:   "4f043662-2ed6-45b0-8c3a-77d685716e28/asia-northeast1/2",
 		},
 		QosType: "guarantee",
@@ -232,10 +236,11 @@ const updateRequest = `
             "primary": {
                 "asPathPrepend": {
                     "in": 1,
-                    "out": 2
+                    "out": 1
                 }
             }
-        }
+        },
+        "bandwidth": "200M"
     }
 }
 `
@@ -244,11 +249,12 @@ var updateResponse = fmt.Sprintf(`
 {
     "connection": {
         "id": "%s",
-        "tenantId": "87e89b8f075a4ee1aa209f6ca6ce242c",
-        "operationStatus": "Processing",
-        "redundant": false,
         "name": "YourConnectionName",
-        "bandwidth": "300M",
+        "redundant": false,
+        "tenantId": "87e89b8f075a4ee1aa209f6ca6ce242c",
+        "area": "JPEAST",
+        "operationStatus": "Processing",
+        "bandwidth": "200M",
         "source": {
             "routerId": "F020123456789",
             "groupName": "group_1",
@@ -259,13 +265,13 @@ var updateResponse = fmt.Sprintf(`
             "primary": {
                 "asPathPrepend": {
                     "in": 1,
-                    "out": 2
+                    "out": 1
                 }
             }
         },
         "destination": {
             "primary": {
-                "interconnect": "Equinix-TY2-1",
+                "interconnect": "Equinix-TY2-2",
                 "pairingKey": "4f043662-2ed6-45b0-8c3a-77d685716e28/asia-northeast1/2"
             },
             "qosType": "guarantee"
@@ -281,10 +287,11 @@ var updateResponse = fmt.Sprintf(`
 var connectionUpdated = con.Connection{
 	ID:              idConnection1,
 	TenantID:        "87e89b8f075a4ee1aa209f6ca6ce242c",
+	Area:            "JPEAST",
 	OperationStatus: "Processing",
 	Redundant:       false,
 	Name:            "YourConnectionName",
-	Bandwidth:       "300M",
+	Bandwidth:       "200M",
 	Source: con.Source{
 		RouterID:  "F020123456789",
 		GroupName: "group_1",
@@ -295,13 +302,13 @@ var connectionUpdated = con.Connection{
 		Primary: con.Primary{
 			ASPathPrepend: con.ASPathPrepend{
 				In:  &one,
-				Out: &two,
+				Out: &one,
 			},
 		},
 	},
 	Destination: con.Destination{
 		Primary: con.DestinationHAInfo{
-			Interconnect: "Equinix-TY2-1",
+			Interconnect: "Equinix-TY2-2",
 			PairingKey:   "4f043662-2ed6-45b0-8c3a-77d685716e28/asia-northeast1/2",
 		},
 		QosType: "guarantee",

--- a/fic/eri/v1/router_single_to_gcp_connections/testing/requests_test.go
+++ b/fic/eri/v1/router_single_to_gcp_connections/testing/requests_test.go
@@ -125,14 +125,14 @@ func TestCreateConnection(t *testing.T) {
 			},
 			Primary: con.Primary{
 				ASPathPrepend: con.ASPathPrepend{
-					In:  &one,
+					In:  &null,
 					Out: &null,
 				},
 			},
 		},
 		Destination: con.Destination{
 			Primary: con.DestinationHAInfo{
-				Interconnect: "Equinix-TY2-1",
+				Interconnect: "Equinix-TY2-2",
 				PairingKey:   "4f043662-2ed6-45b0-8c3a-77d685716e28/asia-northeast1/2",
 			},
 			QosType: "guarantee",
@@ -191,10 +191,11 @@ func TestUpdateConnection(t *testing.T) {
 			Primary: con.Primary{
 				ASPathPrepend: con.ASPathPrepend{
 					In:  &one,
-					Out: &two,
+					Out: &one,
 				},
 			},
 		},
+		Bandwidth: "200M",
 	}
 	c, err := con.Update(fakeclient.ServiceClient(), idConnection1, updateOpts).Extract()
 	th.AssertNoErr(t, err)


### PR DESCRIPTION
Supports the following parameters in Router to GCP Connection
- connection.source.primary.med.out
- connection.source.secondary.med.out
- connection.area
- connection.bandwidth