### PR TITLE
Add parameters to ecl connection update

### DIFF
--- a/fic/eri/v1/router_to_ecl_connections/doc.go
+++ b/fic/eri/v1/router_to_ecl_connections/doc.go
@@ -75,7 +75,7 @@ Example to Delete a Connection
 Example to Update a Connection
 
 	updateOpts := con.UpdateOpts{
-		Source: con.SourceForUpdate{
+		Source: &con.SourceForUpdate{
 			con.RouteFilter{
 				In:  "fullRoute",
 				Out: "fullRouteWithDefaultRoute",

--- a/fic/eri/v1/router_to_ecl_connections/requests.go
+++ b/fic/eri/v1/router_to_ecl_connections/requests.go
@@ -132,7 +132,9 @@ type SourceForUpdate struct {
 
 // UpdateOpts represents options used to update a connection.
 type UpdateOpts struct {
-	Source SourceForUpdate `json:"source"`
+	Name      string           `json:"name,omitempty"`
+	Source    *SourceForUpdate `json:"source,omitempty"`
+	Bandwidth string           `json:"bandwidth,omitempty"`
 }
 
 // ToUpdateMap builds a request body from UpdateOpts.

--- a/fic/eri/v1/router_to_ecl_connections/testing/fixtures.go
+++ b/fic/eri/v1/router_to_ecl_connections/testing/fixtures.go
@@ -184,7 +184,14 @@ var connectionCreated = con.Connection{
 	OperationID:                      "d981d661a4be48bca8b748a84b0325c4",
 }
 
-const updateRequest = `
+const updateNameRequest = `
+{
+    "connection": {
+        "name": "YourConnectionName"
+    }
+}`
+
+const updateSourceRequest = `
 {
     "connection": {
         "source": {
@@ -193,6 +200,13 @@ const updateRequest = `
                 "out": "fullRouteWithDefaultRoute"
             }
         }
+    }
+}`
+
+const updateBandwidthRequest = `
+{
+    "connection": {
+        "bandwidth": "100M"
     }
 }`
 


### PR DESCRIPTION
Router to ECL Connectionリソースでnameとbandwidthを更新できるように修正しました。
その結果source, name, bandwidthが更新できるようになります。しかし、1リクエストで1つのフィールドしか更新できないAPI仕様なのでテストケースは分離しています。
https://fic.ntt.com/documents/api-references/connection-ecl/rsts/Router%20to%20ECL.html#update-router-to-ecl2-0-connection