### PR TITLE
:bug: IF-10137 Allow blank list for updating firewall

### DIFF
--- a/fic/eri/v1/routers/components/firewalls/requests.go
+++ b/fic/eri/v1/routers/components/firewalls/requests.go
@@ -141,10 +141,10 @@ type RoutingGroupSetting struct {
 
 // UpdateOpts represents options used to activate a firewall.
 type UpdateOpts struct {
-	Rules                []Rule                `json:"rules,omitempty"`
-	CustomApplications   []CustomApplication   `json:"customApplications,omitempty"`
-	ApplicationSets      []ApplicationSet      `json:"applicationSets,omitempty"`
-	RoutingGroupSettings []RoutingGroupSetting `json:"routingGroupSettings,omitempty"`
+	Rules                []Rule                `json:"rules"`
+	CustomApplications   []CustomApplication   `json:"customApplications"`
+	ApplicationSets      []ApplicationSet      `json:"applicationSets"`
+	RoutingGroupSettings []RoutingGroupSetting `json:"routingGroupSettings"`
 }
 
 // ToUpdateMap builds a request body from UpdateOpts.


### PR DESCRIPTION
* fic/eri/v1/routers/components/firewalls/requests.go
  - 値が空リストのとき、項目自体を削除(omitempty)ではなく空リストをリクエストに指定するよう修正